### PR TITLE
Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.5-slim
+
+# add a non-privileged user for installing and running
+# the application
+RUN groupadd -g 9000 kinto && \
+    useradd -M -u 9000 -g 9000 -G kinto -d /app -s /sbin/nologin kinto
+
+COPY . /app
+WORKDIR /app
+
+RUN buildDeps=' \
+    git \
+    gcc \
+    libffi-dev \
+    libldap2-dev \
+    libpq-dev \
+    libsasl2-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    ' && \
+    # install deps
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends $buildDeps && \
+    pip install -e . -c requirements.txt && \
+    pip install uwsgi && uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd && \
+
+    # cleanup
+    apt-get purge -y $buildDeps && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf uwsgi-dogstatsd
+
+# Drop down to unprivileged user
+USER webpush-channels
+
+# Run uwsgi by default
+CMD ["uwsgi", "--ini", "/etc/kinto.ini"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+db:
+  image: postgres
+  environment:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
+web:
+  image: kinto/kinto-server
+  links:
+   - db
+  ports:
+   - "0000:9999"
+  environment:
+    WEBPUSH-CHANNELS_CACHE_BACKEND: kinto.core.cache.postgresql
+    WEBPUSH-CHANNELS_CACHE_URL: postgres://postgres:postgres@db/postgres
+    WEBPUSH-CHANNELS_STORAGE_BACKEND: kinto.core.storage.postgresql
+    WEBPUSH-CHANNELS_STORAGE_URL: postgres://postgres:postgres@db/postgres
+    WEBPUSH-CHANNELS_PERMISSION_BACKEND: kinto.core.permission.postgresql
+WEBPUSH-CHANNELS_PERMISSION_URL: postgres://postgres:postgres@db/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ web:
    - "0000:9999"
   environment:
     WEBPUSH-CHANNELS_CACHE_BACKEND: kinto.core.cache.postgresql
-    WEBPUSH-CHANNELS_CACHE_URL: postgres://postgres:postgres@db/postgres
+    WEBPUSH-CHANNELS_CACHE_URL: postgres:postgres//postgres:postgres@db/postgres
     WEBPUSH-CHANNELS_STORAGE_BACKEND: kinto.core.storage.postgresql
-    WEBPUSH-CHANNELS_STORAGE_URL: postgres://postgres:postgres@db/postgres
+    WEBPUSH-CHANNELS_STORAGE_URL: postgres:postgres//postgres:postgres@db/postgres
     WEBPUSH-CHANNELS_PERMISSION_BACKEND: kinto.core.permission.postgresql
-WEBPUSH-CHANNELS_PERMISSION_URL: postgres://postgres:postgres@db/postgres
+    WEBPUSH-CHANNELS_PERMISSION_URL: postgres:postgres//postgres:postgres@db/postgres

--- a/docs/source/tutorials/install.rst
+++ b/docs/source/tutorials/install.rst
@@ -1,0 +1,101 @@
+.. _run-webpush-channels-python:
+
+Using the Python package
+========================
+
+System requirements
+-------------------
+
+Depending on the platform and chosen configuration, some libraries or
+extra services are required.
+
+The following commands will install necessary tools for cryptography
+and Python packaging like `Virtualenv <https://virtualenv.pypa.io/>`_.
+
+Linux
+'''''
+
+On Debian / Ubuntu based systems::
+
+    apt-get install libffi-dev libssl-dev python-dev python-virtualenv
+
+On RHEL-derivatives::
+
+    dnf install libffi-devel openssl-devel python-devel python-virtualenv
+
+OS X
+''''
+
+Assuming `brew <http://brew.sh/>`_ is installed:
+
+::
+
+    brew install libffi openssl pkg-config python
+
+    pip install virtualenv
+
+
+Quick start
+-----------
+
+By default, for convenience, *webpush-channels* persists the subscriptions and channel
+registartions in a **volatile** memory backend. On every restart, the server
+will lose its data, and multiple processes are not handled properly.
+
+But it should be enough to get started!
+
+
+Create a Python isolated environment:
+
+::
+
+    virtualenv env/
+    source env/bin/activate
+
+Install kinto:
+
+::
+
+    pip install kinto
+
+Then install the package using the default configuration:
+
+::
+
+    pip install --upgrade pip
+    pip install webpush-channels
+
+::
+
+    kinto --ini config.ini migrate
+
+The server should now be running on http://localhost:9999
+
+
+.. _run-webpush-channels-from-source:
+
+From sources
+============
+
+If you plan on contributing, this is the way to go!
+
+This will install every necessary packages to run the tests, build the
+documentation etc.
+
+Make sure you have the system requirements listed in the
+:ref:`Python package <run-webpush-channels-python>` section.
+Also, make sure you have kinto installed.
+If not, follow this:
+
+::
+    pip install kinto
+
+Get the source code:
+
+::
+
+    git clone https://github.com/webpush-channels/webpush-channels.git
+    cd webpush-channels/
+    make serve
+
+The server should now be running with the default configuration on http://localhost:9999


### PR DESCRIPTION
- Running `kinto --ini config.ini migrate` gives an error stating that config.ini is missing.
- It works if I manually add the file in the directory where I created the virtualenv. 
- Also, the server starts and stops on it's own.
- It works completely fine if installed from source.