### PR TITLE
Added installation instructions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,8 @@ WebPush Channel Broadcast Documentation
    :caption: Contents:
 
    overview
+   tutorials/index
    api/index
-
 
 Indices and tables
 ==================

--- a/docs/source/tutorials/first-steps.rst
+++ b/docs/source/tutorials/first-steps.rst
@@ -1,0 +1,129 @@
+.. _tutorial-first-steps:
+
+First steps with webpush-channels API
+#####################################
+
+This tutorial will take you through your first API calls with a real
+webpush-channels server.
+
+In order to get the most out of this tutorial, you may want to have a
+real webpush-channels server ready. You can read our :ref:`installation
+<install>` guide to see how to set up your own webpush-channels instance if you
+like. We'll be using the :ref:`Mozilla demo server <run-webpush-channels-mozilla-demo>`.
+
+.. important::
+
+    In this tutorial we will use a Basic Authentication, which computes a
+    user id based on the token provided in the request.
+
+    This method has many limitations but has the advantage of not needing
+    specific setup or third-party services before you get started.
+
+    :ref:`Read more about authentication in webpush-channels <authentication>`.
+
+subscription and channel APIs
+=============================
+
+Using the `httpie <http://httpie.org>`_ tool we can post a sample subscription:
+
+.. note::
+
+    Please `consider reading httpie documentation <https://github.com/jkbrzt/httpie#proxies>`_
+    for more information (if you need to configure a proxy, for instance).
+
+.. code-block:: shell
+
+    $ echo '{"data": {"endpoint": "https://updates.push.services.mozilla.com/wpush/v1/gAAAAABYZNChoTLTAeA9vv-_zeqGuZiM4ESpiV7oiT5XtrN8aI01fiCQ7-_hC8lhqXanjUEWp5MFRoq35QmzdplCkRhp5nRgjwneGCGO8WXYH9psZaD_xInKLWm7K8-tzFAp-vRNHx79","keys": {"auth": "pnipzxpMvKBNYZAcxc-MAA","p256dh": "BEVoH6cOlNPuvYR0aVJo4GVv84nbymzpXxNff7hpKYjVIFcuIEtqiLtIe4rLOXF_A2w3KWRJoCYJEjUedrXcNpc"}}}' | http POST https://webpush-channels.dev.mozaws.net/v0/subscriptions -v --auth 'token:my-secret'
+
+.. code-block:: http
+
+    HTTP/1.1 201 Created
+    Access-Control-Expose-Headers: Retry-After, Backoff, Content-Length, Alert
+    Connection: keep-alive
+    Content-Length: 457
+    Content-Type: application/json
+    Date: Mon, 06 Mar 2017 08:46:54 GMT
+    ETag: "1488790014966"
+    Last-Modified: Mon, 06 Mar 2017 08:46:54 GMT
+    Server: nginx
+    X-Content-Type-Options: nosniff
+
+    {
+        "data": {
+            "endpoint": "https://updates.push.services.mozilla.com/wpush/v1/gAAAAABYZNChoTLTAeA9vv-_zeqGuZiM4ESpiV7oiT5XtrN8aI01fiCQ7-_hC8lhqXanjUEWp5MFRoq35QmzdplCkRhp5nRgjwneGCGO8WXYH9psZaD_xInKLWm7K8-tzFAp-vRNHx79",
+            "id": "2bc46e881676cd7321d12e9e2deb5c46e3ad8ccabaf580df3fc104fc46e114e1",
+            "keys": {
+                "auth": "pnipzxpMvKBNYZAcxc-MAA",
+                "p256dh": "BEVoH6cOlNPuvYR0aVJo4GVv84nbymzpXxNff7hpKYjVIFcuIEtqiLtIe4rLOXF_A2w3KWRJoCYJEjUedrXcNpc"
+            },
+            "last_modified": 1488790014966
+        }
+    }
+
+
+.. note::
+
+    With *Basic Auth* a unique identifier needs to be associated with each
+    user. This identifier is built using the token value provided in the request.
+    Therefore users cannot change their password easily without losing
+    access to their data. :ref:`More information <authentication>`.
+
+Let us register for a channel named 'blah' now:
+
+.. code-block:: shell
+
+    $ http PUT https://webpush-channels.dev.mozaws.net/v0/channels/blah/registration \
+           -v --auth 'token:my-secret'
+
+.. code-block:: http
+
+    HTTP/1.1 202 Accepted
+    Access-Control-Expose-Headers: Retry-After, Backoff, Content-Length, Alert
+    Connection: keep-alive
+    Content-Length: 33
+    Content-Type: application/json
+    Date: Mon, 06 Mar 2017 08:50:52 GMT
+    Server: nginx
+    X-Content-Type-Options: nosniff
+
+    {
+        "code": 202,
+        "message": "Accepted"
+    }
+
+To be able to post messages to a channel:
+
+.. code-block:: shell
+
+    $ http POST https://webpush-channels.dev.mozaws.net/v0/channels/blah \
+           -v --auth 'token:my-secret'
+
+.. code-block:: http
+
+    HTTP/1.1 202 Accepted
+    Access-Control-Expose-Headers: Retry-After, Backoff, Content-Length, Alert
+    Connection: keep-alive
+    Content-Length: 33
+    Content-Type: application/json
+    Date: Mon, 06 Mar 2017 08:58:50 GMT
+    Server: nginx
+    X-Content-Type-Options: nosniff
+
+    {
+        "code": 202,
+        "message": "Accepted"
+    }
+
+Conclusion
+==========
+
+In this tutorial you have seen some of the concepts exposed by *webpush-channels*:
+
+- Subscribing for push notifications
+- Registering for a channel
+- Pushing a message through mozilla push server
+
+.. note::
+
+    We are working to improve our documentation and make sure it is as easy as
+    possible to get started with *webpush-channels*.

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -1,0 +1,10 @@
+.. _tutorials:
+
+Tutorials
+#########
+
+.. toctree::
+   :maxdepth: 1
+
+   install
+   first-steps

--- a/docs/source/tutorials/install.rst
+++ b/docs/source/tutorials/install.rst
@@ -1,3 +1,10 @@
+.. _run-webpush-channels-mozilla-demo:
+
+Mozilla demo server
+===================
+
+A webpush-channels instance is running at https://webpush-channels.dev.mozaws.net/v0/
+
 .. _run-webpush-channels-python:
 
 Using the Python package

--- a/docs/source/tutorials/install.rst
+++ b/docs/source/tutorials/install.rst
@@ -1,0 +1,101 @@
+.. _run-webpush-channels-python:
+
+Using the Python package
+========================
+
+System requirements
+-------------------
+
+Depending on the platform and chosen configuration, some libraries or
+extra services are required.
+
+The following commands will install necessary tools for cryptography
+and Python packaging like `Virtualenv <https://virtualenv.pypa.io/>`_.
+
+Linux
+'''''
+
+On Debian / Ubuntu based systems::
+
+    apt-get install libffi-dev libssl-dev python-dev python-virtualenv
+
+On RHEL-derivatives::
+
+    dnf install libffi-devel openssl-devel python-devel python-virtualenv
+
+OS X
+''''
+
+Assuming `brew <http://brew.sh/>`_ is installed:
+
+::
+
+    brew install libffi openssl pkg-config python
+
+    pip install virtualenv
+
+
+Quick start
+-----------
+
+By default, for convenience, *webpush-channels* persists the subscriptions and channel
+registartions in a **volatile** memory backend. On every restart, the server
+will lose its data, and multiple processes are not handled properly.
+
+But it should be enough to get started!
+
+
+Create a Python isolated environment:
+
+::
+
+    virtualenv env/
+    source env/bin/activate
+
+Install kinto:
+
+::
+
+    pip install kinto
+
+Then install the package using the default configuration:
+
+::
+
+    pip install --upgrade pip
+    pip install webpush-channels
+
+::
+
+    kinto --ini config.ini migrate
+
+The server should now be running on http://localhost:9999
+
+
+.. _run-webpush-channels-from-source:
+
+From sources
+============
+
+If you plan on contributing, this is the way to go!
+
+This will install every necessary packages to run the tests, build the
+documentation etc.
+
+Make sure you have the system requirements listed in the
+:ref:`Python package <run-webpush-channels-python>` section.
+Also, make sure you have kinto installed.
+If not, follow this:
+
+::
+    pip install kinto
+
+Get the source code:
+
+::
+
+    git clone https://github.com/webpush-channels/webpush-channels.git
+    cd webpush-channels/
+    make serve
+
+The server should now be running with the default configuration on http://localhost:9999


### PR DESCRIPTION
- Running `kinto --ini config.ini migrate` gives an error stating that the config.ini file is missing
- If I manually add the config.ini file to the directory containing the virtualenv, the above command works.
- The server starts and stops automatically when the above stated command is run.
- The server runs perfectly fine when run from source.